### PR TITLE
Improvements for PHP 8, and phpstan errors fixes

### DIFF
--- a/src/Request/Metric.php
+++ b/src/Request/Metric.php
@@ -30,7 +30,7 @@ class Metric implements \JsonSerializable
     /**
      * Add custom hostname to metric
      */
-    public function withHostname(string $hostname): self
+    public function withHostname(string $hostname): static
     {
         $this->hostname = $hostname;
         return $this;
@@ -39,7 +39,7 @@ class Metric implements \JsonSerializable
     /**
      * Add custom timestamp to metric
      */
-    public function withTimestamp(int $timestamp): self
+    public function withTimestamp(int $timestamp): static
     {
         $this->timestamp = $timestamp;
         return $this;

--- a/src/Request/Metric.php
+++ b/src/Request/Metric.php
@@ -17,12 +17,14 @@ class Metric implements \JsonSerializable
 
     public function __construct(
         string $itemKey,
-        string|int|float $itemValue
+        string|int|float $itemValue,
+        string|null $hostname = null,
+        int|null $time = null
     ) {
         $this->itemKey = $itemKey;
         $this->itemValue = $itemValue;
-        $this->hostname = gethostname();
-        $this->timestamp = time();
+        $this->hostname = $hostname ?? gethostname();
+        $this->timestamp = $time ?? time();
     }
 
     /**

--- a/src/Request/Metric.php
+++ b/src/Request/Metric.php
@@ -7,29 +7,17 @@ namespace Zarplata\Zabbix\Request;
  */
 class Metric implements \JsonSerializable
 {
-    /**
-     * @var string
-     */
-    private $itemKey;
+    private string $itemKey;
 
-    /**
-     * @var string
-     */
-    private $itemValue;
+    private string|int|float $itemValue;
 
-    /**
-     * @var string
-     */
-    private $hostname;
+    private string $hostname;
 
-    /**
-     * @var int
-     */
-    private $timestamp;
+    private int $timestamp;
 
     public function __construct(
         string $itemKey,
-        string $itemValue
+        string|int|float $itemValue
     ) {
         $this->itemKey = $itemKey;
         $this->itemValue = $itemValue;
@@ -39,10 +27,8 @@ class Metric implements \JsonSerializable
 
     /**
      * Add custom hostname to metric
-     *
-     * @param string $hostname
      */
-    public function withHostname(string $hostname): static
+    public function withHostname(string $hostname): self
     {
         $this->hostname = $hostname;
         return $this;
@@ -50,16 +36,17 @@ class Metric implements \JsonSerializable
 
     /**
      * Add custom timestamp to metric
-     *
-     * @param int $timestamp
      */
-    public function withTimestamp(int $timestamp): static
+    public function withTimestamp(int $timestamp): self
     {
         $this->timestamp = $timestamp;
         return $this;
     }
 
-    #[\ReturnTypeWillChange]
+    /**
+     * @return array<string, string|int|float>
+     * @phpstan-return array{host: string, key: string, value: string|int|float, clock: int}
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/src/Request/Packet.php
+++ b/src/Request/Packet.php
@@ -10,13 +10,17 @@ use Zarplata\Zabbix\Request\Metric as ZabbixMetric;
 class Packet implements \JsonSerializable
 {
     /**
-     * @var array
+     * @var array<string, string|ZabbixMetric[]>
+     * @phpstan-var array{request: string, data: ZabbixMetric[]}
      */
-    private $packet = [];
+    private array $packet;
 
     public function __construct(string $request = 'sender data')
     {
-        $this->packet['request'] = $request;
+        $this->packet = [
+            'request' => $request,
+            'data' => [],
+        ];
     }
 
     public function addMetric(ZabbixMetric $metric): void
@@ -24,12 +28,19 @@ class Packet implements \JsonSerializable
         $this->packet['data'][] = $metric;
     }
 
+    /**
+     * @return array<string, string|ZabbixMetric[]>
+     * @phpstan-return array{request: string, data: ZabbixMetric[]}
+     */
     public function getPacket(): array
     {
         return $this->packet;
     }
 
-    #[\ReturnTypeWillChange]
+    /**
+     * @return array<string, string|ZabbixMetric[]>
+     * @phpstan-return array{request: string, data: ZabbixMetric[]}
+     */
     public function jsonSerialize(): array
     {
         return $this->packet;

--- a/src/Response.php
+++ b/src/Response.php
@@ -12,31 +12,20 @@ class Response
 {
     private const SUCCESS_RESPONSE = 'success';
 
-    /*
-     * @var string
-     */
-    private $responceStatus;
+    private string $responceStatus;
+
+    private int $processedItems;
+
+    private int $failedItems;
+
+    private int $totalItems;
+
+    private float $secondSpent;
 
     /**
-     * @var int
+     * @param array<string, string> $response
+     * @phpstan-param array{response?: string, info?: string} $response
      */
-    private $processedItems;
-
-    /**
-     * @var int
-     */
-    private $failedItems;
-
-    /**
-     * @var int
-     */
-    private $totalItems;
-
-    /**
-     * @var float
-     */
-    private $secondSpent;
-    
     public function __construct(array $response)
     {
         $this->parseZabbixResponse($response);
@@ -62,21 +51,25 @@ class Response
         return $this->totalItems;
     }
 
+    public function getSecondSpent(): float
+    {
+        return $this->secondSpent;
+    }
+
     /**
      * Parse array to Response class properties
      *
      * This method takes array of values through argument
      * check required fields - `response` and `info` and
      * trying to find information about processed items
-     * to zabbix server through reqular expression.
+     * to zabbix server through regular expression.
      *
-     * @param array $response
-     *
-     * @return void
+     * @param array<string, string> $response
+     * @phpstan-param array{response?: string, info?: string} $response
      *
      * @throws ZabbixResponseException
      */
-    private function parseZabbixResponse(array $response)
+    private function parseZabbixResponse(array $response): void
     {
         if (!isset($response['response'])) {
             throw new ZabbixResponseException(
@@ -132,7 +125,7 @@ class Response
          * $matches[1] - 2 (processed)
          * $matches[2] - 0 (failed)
          * $matches[3] - 2 (total)
-         * $matches[4] - 0.000059 (secods spent)
+         * $matches[4] - 0.000059 (seconds spent)
          */
         $this->processedItems = intval($matches[1]);
         $this->failedItems = intval($matches[2]);

--- a/src/ZabbixSender.php
+++ b/src/ZabbixSender.php
@@ -6,27 +6,29 @@ use Zarplata\Zabbix\Request\Packet as ZabbixPacket;
 use Zarplata\Zabbix\Response as ZabbixResponse;
 use Zarplata\Zabbix\Exception\ZabbixNetworkException;
 use Zarplata\Zabbix\Exception\ZabbixResponseException;
+use Exception;
+use Socket;
 
 class ZabbixSender
 {
     /**
      * Instance instances array
      *
-     * @var array
+     * @var array<string, ZabbixSender>
      */
-    protected static $instances = array();
+    protected static array $instances = [];
 
     /**
      *  Zabbix protocol header
      *
-     *  @var string
+     * @var string
      */
     private const HEADER = 'ZBXD';
 
     /**
      *  Zabbix protocol version
      *
-     *  @var int
+     * @var int
      */
     private const VERSION = 1;
 
@@ -38,37 +40,24 @@ class ZabbixSender
      */
     private const RESPONSE_HEADER_LENGTH = 13;
 
-    /**
-     *  @var string
-     */
-    private $serverAddress;
+    private string $serverAddress;
+
+    private int $serverPort;
 
     /**
-     *  @var int
+     * Disable send operation
      */
-    private $serverPort;
+    private bool $disable = false;
 
     /**
-     * @var ZabbixPacket
-     */
-    private $packet;
-
-    /**
-     * @var bool Disable send operation
-     */
-    private $disable = false;
-
-    /**
-     * Create singletone object
+     * Create singleton object
      *
      * @param string $name Name of object
-     *
-     * @return ZabbixSender instance
      */
-    public static function instance($name = 'default')
+    public static function instance(string $name = 'default'): ZabbixSender
     {
         if (!isset(self::$instances[$name])) {
-            self::$instances[$name] = new static($name);
+            self::$instances[$name] = new self($name);
         }
 
         return self::$instances[$name];
@@ -85,11 +74,12 @@ class ZabbixSender
     /**
      * Configure connection parameters to Zabbix server
      *
-     * @param array $options Configuration options
+     * @param array<string, string|int|bool> $options Configuration options
+     * @phpstan-param array{server_address?: string, server_port?: int, disable?: bool } $options
      *
-     * @return Configurated instance
+     * @return ZabbixSender Configurated instance
      */
-    public function configure(array $options = array())
+    public function configure(array $options = []): ZabbixSender
     {
         if (isset($options['server_address'])) {
             $this->serverAddress = $options['server_address'];
@@ -110,27 +100,20 @@ class ZabbixSender
      * Disable sender functionality. It may be necessary if you want
      * switch off send metrics but you don't want remove the code
      * from your project.
-     *
-     * @return void
      */
-    public function disable() {
+    public function disable(): void {
         $this->disable = true;
     }
 
     /**
      * Enable sender functionality. This is reverse operation of `disable()`
-     *
-     * @return void
      */
-    public function enable() {
+    public function enable(): void {
         $this->disable = false;
     }
 
     /**
      * Send packet of metrics to Zabbix server through network socket
-     *
-     *
-     * @param ZabbixPacket $packet
      *
      * @throws Exception
      * @throws ZabbixNetworkException
@@ -147,7 +130,7 @@ class ZabbixSender
         $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
 
         if (!$socket) {
-            throw new \Exception("can't create TCP socket");
+            throw new Exception("can't create TCP socket");
         }
 
         $socketConnected = socket_connect(
@@ -209,12 +192,15 @@ class ZabbixSender
     private function makePayload(ZabbixPacket $packet): string
     {
         $encodedPacket = json_encode($packet);
+        if ($encodedPacket === false) {
+            throw new Exception('Unable to decode JSON for: ' . $encodedPacket);
+        }
+
         return self::zbxCreateHeader(strlen($encodedPacket)) . $encodedPacket;
     }
 
     /**
      * Zabbix Packet Header
-     *
      */
     public static function zbxCreateHeader(int $plain_data_size, int|null $compressed_data_size = null): string
     {
@@ -233,12 +219,11 @@ class ZabbixSender
     /**
      * Check response from Zabbix server
      *
-     * @param resource $socket
      *
      * @throws ZabbixResponseException
      * @throws ZabbixNetworkException
      */
-    private function checkResponse($socket): ZabbixResponse
+    private function checkResponse(Socket $socket): ZabbixResponse
     {
         $responseBuffer = "";
         $responseBufferLength = 2048;
@@ -250,7 +235,7 @@ class ZabbixSender
             0
         );
 
-        if (!$bytesCount) {
+        if (!$bytesCount || !is_string($responseBuffer)) {
             throw new ZabbixNetworkException(
                 "can't receive response from socket"
             );
@@ -265,19 +250,14 @@ class ZabbixSender
             true
         );
 
-        switch (true) {
-            case $response === null:
-            case $response === false:
-                throw new ZabbixResponseException(
-                    sprintf(
-                        "can't decode zabbix server response %s, reason: %s",
-                        $responseWithoutHeader,
-                        json_last_error_msg()
-                    )
-                );
-
-            default:
-                break;
+        if (!is_array($response)) {
+            throw new ZabbixResponseException(
+                sprintf(
+                    "can't decode zabbix server response %s, reason: %s",
+                    $responseWithoutHeader,
+                    json_last_error_msg()
+                )
+            );
         }
 
         $zabbixResponse = new ZabbixResponse($response);

--- a/src/ZabbixSender.php
+++ b/src/ZabbixSender.php
@@ -9,6 +9,7 @@ use Zarplata\Zabbix\Exception\ZabbixResponseException;
 use Exception;
 use Socket;
 
+/** @phpstan-consistent-constructor */
 class ZabbixSender
 {
     /**
@@ -57,7 +58,7 @@ class ZabbixSender
     public static function instance(string $name = 'default'): ZabbixSender
     {
         if (!isset(self::$instances[$name])) {
-            self::$instances[$name] = new self($name);
+            self::$instances[$name] = new static($name);
         }
 
         return self::$instances[$name];

--- a/src/ZabbixSender.php
+++ b/src/ZabbixSender.php
@@ -10,9 +10,9 @@ use Zarplata\Zabbix\Exception\ZabbixResponseException;
 class ZabbixSender
 {
     /**
-     * Instance instances array 
+     * Instance instances array
      *
-     * @var array 
+     * @var array
      */
     protected static $instances = array();
 
@@ -62,8 +62,8 @@ class ZabbixSender
      * Create singletone object
      *
      * @param string $name Name of object
-     * 
-     * @return ZabbixSender instance 
+     *
+     * @return ZabbixSender instance
      */
     public static function instance($name = 'default')
     {
@@ -83,13 +83,13 @@ class ZabbixSender
     }
 
     /**
-     * Configure connection parameters to Zabbix server 
+     * Configure connection parameters to Zabbix server
      *
-     * @param array $options Configuration options 
+     * @param array $options Configuration options
      *
      * @return Configurated instance
      */
-    public function configure(array $options = array()) 
+    public function configure(array $options = array())
     {
         if (isset($options['server_address'])) {
             $this->serverAddress = $options['server_address'];
@@ -108,7 +108,7 @@ class ZabbixSender
 
     /**
      * Disable sender functionality. It may be necessary if you want
-     * switch off send metrics but you don't want remove the code 
+     * switch off send metrics but you don't want remove the code
      * from your project.
      *
      * @return void
@@ -132,15 +132,13 @@ class ZabbixSender
      *
      * @param ZabbixPacket $packet
      *
-     * @return void
-     *
      * @throws Exception
      * @throws ZabbixNetworkException
      */
-    public function send(ZabbixPacket $packet)
+    public function send(ZabbixPacket $packet): ZabbixResponse|null
     {
         if ($this->disable) {
-            return;
+            return null;
         }
 
         $payload = $this->makePayload($packet);
@@ -199,7 +197,7 @@ class ZabbixSender
                 break;
         }
 
-        $this->checkResponse($socket);
+        return $this->checkResponse($socket);
     }
 
     /**
@@ -237,12 +235,10 @@ class ZabbixSender
      *
      * @param resource $socket
      *
-     * @return void
-     *
      * @throws ZabbixResponseException
      * @throws ZabbixNetworkException
      */
-    private function checkResponse($socket)
+    private function checkResponse($socket): ZabbixResponse
     {
         $responseBuffer = "";
         $responseBufferLength = 2048;
@@ -291,5 +287,7 @@ class ZabbixSender
                 'zabbix server returned non-successfull response'
             );
         }
+
+        return $zabbixResponse;
     }
 }


### PR DESCRIPTION
I fixed all of the code base, using phpstan to find the defects
It now passes level 10, more types where added.
And since we require PHP 8, I could add them natively.

The commit 689dcea6c8c746a09b7284223f02c9a6d283f4b3 was done in 2023 internally.

Some of the code used `static` instead of `self`, I did read some documentation and kept it like it was:
- https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static
- https://dev.to/karleb/self-and-static-in-php-and-their-differences-48b7 

There is not backward incompatible changes in this pull request

The commit 8de680485cc479f36df3702fc4dc379844b0587f adds an override to provide the Metric time and hostname, that does reduce some system calls that are not needed if you anyway would call `->withHostname` right after

`#[\ReturnTypeWillChange]` where not needed anymore since we changed the signature (from #4).


------
Test with phpstan locally:
```console
$ wget https://github.com/phpstan/phpstan/releases/download/2.1.31/phpstan.phar
$ php -f ./phpstan.phar analyse --level=max ./


 ------ -------------------------------------------------------------------------------------------
  Line   Request/Metric.php
 ------ -------------------------------------------------------------------------------------------
  26     Property Zarplata\Zabbix\Request\Metric::$hostname (string) does not accept string|false.
         🪪  assign.propertyType
 ------ -------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------
  Line   ZabbixSender.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------
  264    Parameter #1 $response of class Zarplata\Zabbix\Response constructor expects array{response?: string, info?: string}, array<mixed, mixed> given.
         🪪  argument.type
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------


 [ERROR] Found 2 errors
```

The two left errors are no big deal and do not need to be fixed